### PR TITLE
Make SpecifiedTradeSettlementPaymentMeans element optional

### DIFF
--- a/src/Pyrexx/ZUGFeRD/Model/Trade/Settlement.php
+++ b/src/Pyrexx/ZUGFeRD/Model/Trade/Settlement.php
@@ -70,7 +70,6 @@ class Settlement
     {
         $this->paymentReference = $paymentReference;
         $this->currency = $currency;
-        $this->paymentMeans = new PaymentMeans();
     }
 
     /**


### PR DESCRIPTION
Based on ZUGFeRD documentation **SpecifiedTradeSettlementPaymentMeans** element is optional.
See https://konik.io/ZUGFeRD-Spezifikation/Das-ZUGFeRD-Format_1p0_technische_Dokumentation.pdf at page 70.